### PR TITLE
fix(docs): drop the shortcodes from the sidebar labels

### DIFF
--- a/docs/_sidebar-getting-started.yml
+++ b/docs/_sidebar-getting-started.yml
@@ -1,15 +1,22 @@
 website:
   sidebar:
+    # No shortcode in the `contents` labels below. Quarto renders a sidebar
+    # label by substituting the rendered markdown back onto the element, keyed
+    # by that element's own innerHTML, which the DOM has HTML-escaped by then.
+    # A shortcode carries `<` and `>`, so the key never matches: the label
+    # loses whatever the shortcode produced, and the breadcrumb built from the
+    # same text keeps the shortcode verbatim. The `title` below is exempt
+    # because Quarto only renders a sidebar header when the site has no navbar.
     - id: getting-started
       title: "{{< iconify octicon:rocket-16 title='Getting started' label='Getting started' >}} Getting started"
       style: floating
       collapse-level: 2
       contents:
-        - text: "{{< iconify octicon:compass-16 title='Overview' label='Overview' >}} Overview"
+        - text: "Overview"
           href: getting-started/index.qmd
-        - text: "{{< iconify octicon:play-16 title='Quick start' label='Quick start' >}} Quick start"
+        - text: "Quick start"
           href: getting-started/quick-start.qmd
-        - text: "{{< iconify octicon:workflow-16 title='How it works' label='How it works' >}} How it works"
+        - text: "How it works"
           href: getting-started/how-it-works.qmd
-        - text: "{{< iconify octicon:code-square-16 title='Recipes' label='Recipes' >}} Recipes"
+        - text: "Recipes"
           href: getting-started/recipes.qmd

--- a/docs/_sidebar-reference.yml
+++ b/docs/_sidebar-reference.yml
@@ -1,23 +1,25 @@
 website:
   sidebar:
+    # No shortcode in the `contents` labels below, for the reason given in
+    # `_sidebar-getting-started.yml`.
     - id: reference
       title: "{{< iconify octicon:book-16 title='Reference' label='Reference' >}} Reference"
       style: floating
       collapse-level: 2
       contents:
-        - text: "{{< iconify octicon:compass-16 title='Overview' label='Overview' >}} Overview"
+        - text: "Overview"
           href: reference/index.qmd
-        - text: "{{< iconify octicon:sliders-16 title='Inputs and outputs' label='Inputs and outputs' >}} Inputs and outputs"
+        - text: "Inputs and outputs"
           href: reference/action.qmd
-        - text: "{{< iconify octicon:versions-16 title='Update selection' label='Update selection' >}} Update selection"
+        - text: "Update selection"
           href: reference/updates.qmd
-        - text: "{{< iconify octicon:git-merge-16 title='Auto-merge' label='Auto-merge' >}} Auto-merge"
+        - text: "Auto-merge"
           href: reference/auto-merge.qmd
-        - text: "{{< iconify octicon:beaker-16 title='Dry-run mode' label='Dry-run mode' >}} Dry-run mode"
+        - text: "Dry-run mode"
           href: reference/dry-run.qmd
-        - text: "{{< iconify octicon:git-pull-request-16 title='Pull requests' label='Pull requests' >}} Pull requests"
+        - text: "Pull requests"
           href: reference/pull-requests.qmd
-        - text: "{{< iconify octicon:database-16 title='Registry and manifests' label='Registry and manifests' >}} Registry and manifests"
+        - text: "Registry and manifests"
           href: reference/registry.qmd
-        - text: "{{< iconify octicon:question-16 title='Troubleshooting' label='Troubleshooting' >}} Troubleshooting"
+        - text: "Troubleshooting"
           href: reference/troubleshooting.qmd


### PR DESCRIPTION
A shortcode in a `website.sidebar.contents` label does not survive Quarto rendering. Quarto substitutes the rendered markdown back onto the element, keyed by that element own innerHTML, which the DOM has HTML-escaped by then; a shortcode carries `<` and `>`, so the key never matches and the substitution is skipped.

That cost three things at once. The sidebar label lost the icon and kept the leading space in front of the text. The breadcrumb built from the same text, which shows on narrow viewports, carried the shortcode verbatim. The page-navigation link put it in its `aria-label`, where a screen reader reads it out.

Removing the shortcodes clears all three: across the rendered site, literal shortcodes go from 12 to 0 and none remain in an `aria-label`. The icons were only ever reaching the page-navigation links, which lose them here; the sidebar had been dropping them all along. The `title` of each sidebar keeps its shortcode, since Quarto renders a sidebar header only when the site has no navbar and this one does.